### PR TITLE
Fixed the exponential distribution and added it

### DIFF
--- a/distributions/Dist_psa251.py
+++ b/distributions/Dist_psa251.py
@@ -16,16 +16,31 @@ class Dist_psa251(BaseDistribution):
     def __init__(self):
         self.x_min = -1.
         self.x_max = 1.
-        self.f_max = 1.
+        self.f_max = 0.75
+        self.mu    = -999.
+
+        # self._k = 1
 
     def pdf(self, x):
-        return 1. - x**2.
+        # print self._k
+        # self._k += 1
+        return self.f_max*(1. - x**2.)
 
     def mean(self):
-        return 0.
+        a = self.x_min
+        b = self.x_max
+
+        self.mu = self.f_max*((0.5*b**2.) - (0.25*b**4.) - (0.5*a**2.) + (0.25*a**2.))
+        return self.mu
 
     def std(self):
-        return np.sqrt(4./15.)
+        if self.mu == -999.:
+            self.mean()
+
+        f0 = self.f_max * ((1./3.)*self.x_min**3. - (1./5.)*self.x_min**5.) - (2.*self.mu**2.) + (self.f_max*self.mu**2.)*(self.x_min - (1./3.)*(self.x_min**3.))
+        f1 = self.f_max * ((1./3.)*self.x_max**3. - (1./5.)*self.x_max**5.) - (2.*self.mu**2.) + (self.f_max*self.mu**2.)*(self.x_max - (1./3.)*(self.x_max**3.))
+
+        return np.sqrt(f1 - f0)
 
 def test(cls):
 	try:

--- a/distributions/Dist_psa251_2.py
+++ b/distributions/Dist_psa251_2.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+import traceback
+
+from base_distribution import BaseDistribution
+
+class Dist_psa251_2(BaseDistribution):
+    # Trying exp. dist again
+    # this time with improper bounds (D: [0, ∞))
+    #
+    # p(x) = λe^(-λx)
+
+    def __init__(self):
+        self.lamda = 1.
+
+        self.x_min = 0.
+        self.x_max = 10 # good enough for an inf approximation?
+        self.f_max = self.lamda
+
+        # self._k = 1
+
+    def pdf(self, x):
+        # print self._k
+        #
+        # self._k += 1
+        return self.lamda*np.exp((-1.)*self.lamda*x)
+
+    def mean(self):
+        return (1./self.lamda)
+
+    def std(self):
+        mu_sq = (1./self.lamda)**2.
+
+        return np.sqrt(mu_sq) # might as well return mu, but this form is from Integral[(x - µ)^2 * p(x) * dx]
+
+
+def test(cls):
+	try:
+		dist = cls()
+		N_test = 100000
+		rvs = dist.rvs(N_test)
+		if np.abs(np.mean(rvs) - dist.mean()) > 2*np.std(rvs)/np.sqrt(N_test):
+			print("means don't match for %s: %f vs. %f" %(cls.__name__,
+														  np.mean(rvs), dist.mean()))
+
+		elif np.abs(np.std(rvs) - dist.std()) > 2*np.std(rvs)/np.sqrt(np.sqrt(1.*N_test)):
+			print("std devs. don't match for %s: %f vs. %f" %(cls.__name__,
+														  np.std(rvs), dist.std()))
+
+		elif np.sum(dist.pdf(np.linspace(dist.x_min,dist.x_max,100))<0) > 0:
+			print("pdf was negative in some places")
+
+		else:
+			print("%s passes tests, adding it" %(cls.__name__))
+	except:
+		print("%s has errors. didn't work" %(cls.__name__))
+        print traceback.print_exc()
+
+if __name__ == '__main__':
+	test(Dist_psa251_2)


### PR DESCRIPTION
(+) Let the max of λe^(-λx) run out to x = 10, which acts as a working
approximation of ∞ while not eating up processing time. RVS and
accept/reject run at about 1e6 iterations, but that’s ~3s computation
time on my laptop, so not too bad. Tightened the error margin to 2σ to
make sure the x=10 approximation worked.

(Δ) Normed the parabolic approximation. Noticed in class that my
distribution was in the faulty bracket. Not sure why unless that copy
was an older edition, which would make sense
